### PR TITLE
handleLoadedVehicle should only send vehicle and activation

### DIFF
--- a/wsdl/tp1-tp2.wsdl
+++ b/wsdl/tp1-tp2.wsdl
@@ -30,7 +30,7 @@
       <element name="saveTrackingDataVehicleResponse" type="impl:SaveTrackingDataVehicleResponse"/>
       <complexType name="HandleLoadedVehicle">
         <sequence>
-          <element name="dgPublication" type="dgt:DGPublication" />
+          <element name="dgTransportUnit" type="dgt:DGTransportUnit"/>
           <element name="activation" type="boolean"/>
         </sequence>
       </complexType>


### PR DESCRIPTION
Change discussed on DGTINA Meeting 13 January 2022: Currently a TP2 can
send way to much data when registering a DG transport. The only
important information is the vehicle identification and the activation /
deactivation flag.